### PR TITLE
Updated poms - The lib is a jar and not an apklib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ local.properties
 /.settings
 
 # Maven files
-/target
+target

--- a/ProviGen/pom.xml
+++ b/ProviGen/pom.xml
@@ -11,7 +11,6 @@
 
     <artifactId>ProviGen-lib</artifactId>
     <name>ProviGen</name>
-    <packaging>apklib</packaging>
 
     <dependencies>
         <dependency>
@@ -56,23 +55,15 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.7</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>attach-artifact</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <type>jar</type>
-                                    <file>${project.build.directory}/${project.build.finalName}.jar</file>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/ProviGenSample/pom.xml
+++ b/ProviGenSample/pom.xml
@@ -23,13 +23,11 @@
             <groupId>com.google.android</groupId>
             <artifactId>support-v4</artifactId>
             <version>r7</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.TimotheeJeannin</groupId>
             <artifactId>ProviGen-lib</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
 		<java.version>1.6</java.version>
 		<android.version>4.1.1.4</android.version>
-		<android.platform>16</android.platform>
+		<android.platform>19</android.platform>
 	</properties>
 
 	<dependencyManagement>
@@ -52,13 +52,17 @@
 		</dependencies>
 	</dependencyManagement>
 
+    <prerequisites>
+        <maven>3.1.1</maven>
+    </prerequisites>
+
 	<build>
 		<pluginManagement>
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.0</version>
+					<version>3.1</version>
 					<configuration>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
@@ -68,7 +72,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.8.0</version>
+					<version>3.8.1</version>
 					<configuration>
 						<sdk>
 							<platform>${android.platform}</platform>


### PR DESCRIPTION
I have updated your poms 

I changed the library from apklib to jar as currently your library does not contain any resources.

Once you add resources I would advice you to set the packaging to aar and use android-maven-plugin 3.8.2+ so your lib can also be used by gradle users (note: it is currently available for everybody as it is a jar)
