### PR TITLE
EMMA support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,10 @@ before_script:
 
 install: /bin/true # always succeeds
 
+before_script:
+    - mvn clean
+
 script: mvn install -Dandroid.device=test
+
+after_success:
+    - mvn clean install site:site site:stage -Pemma

--- a/ProviGen/pom.xml
+++ b/ProviGen/pom.xml
@@ -23,4 +23,38 @@
     <build>
         <sourceDirectory>src</sourceDirectory>
     </build>
+
+    <profiles>
+        <profile>
+            <id>emma</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                        <artifactId>android-maven-plugin</artifactId>
+                        <configuration>
+                            <emma>
+                                <enable>true</enable>
+                                <classFolders>${project.basedir}/target/classes/</classFolders>
+                                <outputMetaFile>${project.basedir}/target/emma/coverage.em</outputMetaFile>
+                            </emma>
+                            <dex>
+                                <noLocals>true</noLocals>
+                            </dex>
+                        </configuration>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>emma</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>emma</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ProviGenTests/AndroidManifest.xml
+++ b/ProviGenTests/AndroidManifest.xml
@@ -12,6 +12,9 @@
         android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="com.tjeannin.provigen.test" />
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"

--- a/ProviGenTests/pom.xml
+++ b/ProviGenTests/pom.xml
@@ -35,6 +35,7 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
 
         <plugins>
             <plugin>
@@ -44,4 +45,74 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>emma</id>
+            <dependencies>
+                <dependency>
+                    <groupId>emma</groupId>
+                    <artifactId>emma</artifactId>
+                    <type>jar</type>
+                    <scope>compile</scope>
+                    <version>2.0.5312</version>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                        <artifactId>android-maven-plugin</artifactId>
+                        <configuration>
+                            <test>
+                                <coverage>true</coverage>
+                                <createReport>true</createReport>
+                            </test>
+                        </configuration>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>pull-coverage</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>pull</goal>
+                                </goals>
+                                <configuration>
+                                    <pullSource>/data/data/com.tjeannin.provigen.test/files/coverage.ec</pullSource>
+                                    <pullDestination>ProviGen/target/emma/coverage.ec</pullDestination>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.maven.plugin</groupId>
+                        <artifactId>emma4it-maven-plugin</artifactId>
+                        <version>1.3</version>
+                        <configuration>
+                            <metadatas>
+                                <file>../ProviGen/target/emma/coverage.em</file>
+                            </metadatas>
+                            <instrumentations>
+                                <file>../ProviGen/target/emma/coverage.ec</file>
+                            </instrumentations>
+                            <reportDirectory>../target/emma/</reportDirectory>
+                            <searchPath>../ProviGen/target/</searchPath>
+                            <sourceFolders>
+                                <sourceFolder>../ProviGen/src</sourceFolder>
+                            </sourceFolders>
+                            <formats>
+                                <format>xml</format>
+                                <format>html</format>
+                            </formats>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+    </profiles>
 </project>

--- a/ProviGenTests/test/com/tjeannin/provigen/test/Dummy.java
+++ b/ProviGenTests/test/com/tjeannin/provigen/test/Dummy.java
@@ -1,0 +1,13 @@
+package com.tjeannin.provigen.test;
+
+import junit.framework.TestCase;
+
+/**
+ * This class must be present to get emma4it report working when running a mvn site:site, because it tries to
+ * do lookup in target/test-classes. When this directory is not present the plugin fails to execute and breaks the build.
+ */
+public class Dummy extends TestCase {
+	public void testCompile() {
+		assertTrue(true);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
         <android-maven-plugin.version>3.8.2</android-maven-plugin.version>
         <versions-maven-plugin.version>2.1</versions-maven-plugin.version>
+        <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+        <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     </properties>
 
 	<dependencyManagement>
@@ -220,6 +222,16 @@
                 </plugin>
 
                 <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven-antrun-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${versions-maven-plugin.version}</version>
@@ -286,6 +298,9 @@
         <plugins>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
+                <configuration>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
- added emma code coverage report on an extra profile named `emma`
- profile emma should never be enabled for releases because of the modifications of the byte code
- on travis the generation of the coverage report and also the generation of the site is only enabled if the build was successful
